### PR TITLE
Api WebApp CI/CD Pipelines

### DIFF
--- a/azure-devops-pipelines/api-webapp-CD.yml
+++ b/azure-devops-pipelines/api-webapp-CD.yml
@@ -6,6 +6,7 @@ pool:
 
 variables:
  - group: web-api-variables
+ - group: pipeline-service-connection
 
 steps:
 - task: AzureCLI@1
@@ -27,6 +28,6 @@ steps:
     azureSubscription: $(azureSubscriptionEndpoint)
     appName: $(appServiceNameApi)
     deployToSlotOrASE: true
-    resourceGroupName: $(resourceGroupName)
+    resourceGroupName: $(webResourceGroupName)
     containers: '$(azureContainerRegistry)/web-api:latest'
     appSettings: '-DOCKER_REGISTRY_SERVER_URL $(registryServerUrl) -DOCKER_REGISTRY_SERVER_USERNAME $(registryUserName) -DOCKER_REGISTRY_SERVER_PASSWORD $(registryPassword) '

--- a/azure-devops-pipelines/api-webapp-CD.yml
+++ b/azure-devops-pipelines/api-webapp-CD.yml
@@ -1,0 +1,32 @@
+# CD pipeline for API WebApp
+# Uses a library for the variables
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+ - group: web-api-variables
+
+steps:
+- task: AzureCLI@1
+  displayName: 'Azure CLI: Save container registry secrets'
+  inputs:
+    azureSubscription: $(azureSubscriptionEndpoint)
+    scriptLocation: inlineScript
+    inlineScript: |
+     registryUserName=$(az acr credential show -n $(azureContainerRegistry) --query username)
+     registryPassword=$(az acr credential show -n $(azureContainerRegistry) --query passwords[0].value)
+     registryServerUrl=$(az acr show -n $(azureContainerRegistry) --query loginServer)
+     echo "##vso[task.setvariable variable=registryUserName]$registryUserName"
+     echo "##vso[task.setvariable variable=registryPassword;issecret=true]$registryPassword"
+     echo "##vso[task.setvariable variable=registryServerUrl]$registryServerUrl"
+
+- task: AzureWebAppContainer@1
+  displayName: 'Azure Web App on Container Deploy'
+  inputs:
+    azureSubscription: $(azureSubscriptionEndpoint)
+    appName: $(appServiceNameApi)
+    deployToSlotOrASE: true
+    resourceGroupName: $(resourceGroupName)
+    containers: '$(azureContainerRegistry)/web-api:latest'
+    appSettings: '-DOCKER_REGISTRY_SERVER_URL $(registryServerUrl) -DOCKER_REGISTRY_SERVER_USERNAME $(registryUserName) -DOCKER_REGISTRY_SERVER_PASSWORD $(registryPassword) '

--- a/azure-devops-pipelines/api-webapp-CI.yml
+++ b/azure-devops-pipelines/api-webapp-CI.yml
@@ -1,6 +1,6 @@
 # CI pipeline for API WebApp
 # Uses a library for the variables
-
+# TODO: Create variable group in preprovisioning to support Web Api
 trigger:
   branches:
     include:

--- a/azure-devops-pipelines/api-webapp-CI.yml
+++ b/azure-devops-pipelines/api-webapp-CI.yml
@@ -1,0 +1,40 @@
+# CI pipeline for API WebApp
+# Uses a library for the variables
+
+trigger:
+  branches:
+    include:
+      - master
+
+# Paths are always specified relative to the root of the repository.
+  paths:
+    exclude:
+      - README.md
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+ - group: web-api-variables
+
+steps:
+- task: Docker@1
+  displayName: 'Build an image'
+  inputs:
+    azureSubscriptionEndpoint: $(azureSubscriptionEndpoint)
+    azureContainerRegistry: $(azureContainerRegistry)
+    dockerFile: src/Web.Api/Dockerfile
+    imageName: '$(azureContainerRegistry)/web-api:latest'
+    useDefaultContext: false
+    buildContext: src/Web.Api
+
+- task: Docker@1
+  displayName: 'Push an image'
+  inputs:
+    azureSubscriptionEndpoint: $(azureSubscriptionEndpoint)
+    azureContainerRegistry: $(azureContainerRegistry)
+    command: 'Push an image'
+    imageName: '$(azureContainerRegistry)/web-api:latest'
+
+
+

--- a/azure-devops-pipelines/api-webapp-CI.yml
+++ b/azure-devops-pipelines/api-webapp-CI.yml
@@ -16,6 +16,7 @@ pool:
 
 variables:
  - group: web-api-variables
+ - group: pipeline-service-connection
 
 steps:
 - task: Docker@1

--- a/azure-devops-pipelines/api-webapp-CI.yml
+++ b/azure-devops-pipelines/api-webapp-CI.yml
@@ -4,7 +4,7 @@
 trigger:
   branches:
     include:
-      - master
+      - main
 
 # Paths are always specified relative to the root of the repository.
   paths:
@@ -35,6 +35,3 @@ steps:
     azureContainerRegistry: $(azureContainerRegistry)
     command: 'Push an image'
     imageName: '$(azureContainerRegistry)/web-api:latest'
-
-
-

--- a/azure-devops-pipelines/web-resource-provisioning.yml
+++ b/azure-devops-pipelines/web-resource-provisioning.yml
@@ -32,7 +32,7 @@ steps:
     terraformVersion: "0.13.2"
     
 - script: |
-    terraform init -backend-config="storage_account_name=$(STORAGE-ACCOUNT-NAME)" -backend-config="container_name=$(STORAGE-STATE-CONTAINER-NAME)" 
+    terraform init -backend-config="storage_account_name=$(STORAGE-ACCOUNT-NAME)"  -backend-config="container_name=$(STORAGE-STATE-CONTAINER-NAME)" -backend-config="key=${{ parameters.prefix }}.web.terraform.tfstate"
     terraform validate
   displayName: "Run TF Validate"
   workingDirectory: $(System.DefaultWorkingDirectory)/src/terraform/web

--- a/azure-devops-pipelines/web-resource-provisioning.yml
+++ b/azure-devops-pipelines/web-resource-provisioning.yml
@@ -57,7 +57,7 @@ steps:
     TF_VAR_client_id: $(ARM-CLIENT-ID)
     TF_VAR_client_secret: $(ARM-CLIENT-SECRET)
     TF_VAR_service_connection_pat: $(DEVOPS-PAT)
-    TF_VAR_prefix: $(prefix)
+    TF_VAR_prefix: ${{ parameters.prefix }}
     TF_VAR_location: $(location)
     TF_VAR_subscription_id: $(ARM-SUBSCRIPTION-ID) 
     TF_VAR_ado_project_name: ${{ parameters.ado_project_name }}

--- a/azure-devops-pipelines/web-resource-provisioning.yml
+++ b/azure-devops-pipelines/web-resource-provisioning.yml
@@ -50,8 +50,11 @@ steps:
     TF_VAR_tenant_id: $(ARM-TENANT-ID)
     TF_VAR_client_id: $(ARM-CLIENT-ID)
     TF_VAR_client_secret: $(ARM-CLIENT-SECRET)
+    TF_VAR_service_connection_pat: $(DEVOPS-PAT)
     TF_VAR_prefix: $(prefix)
     TF_VAR_location: $(location)
     TF_VAR_subscription_id: $(ARM-SUBSCRIPTION-ID) 
+    TF_VAR_ado_project_name: ${{ parameters.ado_project_name }}
+    TF_VAR_ado_org_service_url: ${{ parameters.ado_org_service_url }}
 
 

--- a/azure-devops-pipelines/web-resource-provisioning.yml
+++ b/azure-devops-pipelines/web-resource-provisioning.yml
@@ -6,10 +6,17 @@ trigger: none
 pool:
   vmImage: 'ubuntu-latest'
 
+parameters:
+  - name: prefix
+    displayName: prefix
+    default: "devapi"
+  - name: location
+    displayName: location
+    default: "westus2"
+
 # Using a Variable Group as the Secured Network will be applied post the creation of core 
 variables:
 - group: core-key-vault
-- group: core-variables
 
 steps: 
 # Manual TODO: Install in ADO Organization https://marketplace.visualstudio.com/items?itemName=ms-devlabs.custom-terraform-tasks 

--- a/azure-devops-pipelines/web-resource-provisioning.yml
+++ b/azure-devops-pipelines/web-resource-provisioning.yml
@@ -13,6 +13,12 @@ parameters:
   - name: location
     displayName: location
     default: "westus2"
+  - name: ado_project_name
+    displayName: ado project name eg.-  MyAzureDevopsProject or Azure-PrivateDevopsAgent-Demos-Ansible-Terraform-Pipelines
+    default: Azdo-Modular-Infrastructure-Pipelines
+  - name: ado_org_service_url
+    displayName: ado org service url eg.-  https://dev.azure.com/csebraveheart
+    default: https://dev.azure.com/csebraveheart
 
 # Using a Variable Group as the Secured Network will be applied post the creation of core 
 variables:

--- a/azure-devops-pipelines/web-resource-provisioning.yml
+++ b/azure-devops-pipelines/web-resource-provisioning.yml
@@ -58,7 +58,7 @@ steps:
     TF_VAR_client_secret: $(ARM-CLIENT-SECRET)
     TF_VAR_service_connection_pat: $(DEVOPS-PAT)
     TF_VAR_prefix: ${{ parameters.prefix }}
-    TF_VAR_location: $(location)
+    TF_VAR_location: ${{ parameters.location }}
     TF_VAR_subscription_id: $(ARM-SUBSCRIPTION-ID) 
     TF_VAR_ado_project_name: ${{ parameters.ado_project_name }}
     TF_VAR_ado_org_service_url: ${{ parameters.ado_org_service_url }}

--- a/src/terraform/web/main.tf
+++ b/src/terraform/web/main.tf
@@ -26,6 +26,17 @@ provider "azurerm" {
 #     upper   = false
 # }
 
+#Import azuredevops project via 
+data "azuredevops_project" "main" {
+  project_name = var.ado_project_name
+}
+
+#Initialize local variables for azuredevops project_id and web resource naming conventions
+locals {
+  project_id = data.azuredevops_project.main.id
+
+}
+
 #Create resource group for web resources
 resource "azurerm_resource_group" "api" {
   name     = "${var.prefix}-web-rg"

--- a/src/terraform/web/main.tf
+++ b/src/terraform/web/main.tf
@@ -11,6 +11,13 @@ provider "azurerm" {
   features{}
 }
 
+#Configure azuredevops provider to point to ADO specified instance
+provider "azuredevops" {
+  version = ">= 0.0.1"
+  personal_access_token = var.service_connection_pat
+  org_service_url = var.ado_org_service_url
+}
+
 #If you would like to add a random string uncomment lines 28-36
 #You will then be able to add a random string to your naming convention 
 #This will be helpful to ensure naming conventions do not overlap

--- a/src/terraform/web/variables.tf
+++ b/src/terraform/web/variables.tf
@@ -28,3 +28,15 @@ variable "client_secret" {
   description = "Service Principal Client secret"
   type        = string
 }
+variable "ado_project_name" {
+  description = "AzureDevOps Project Name"
+  type        = string
+}
+variable "service_connection_pat" {
+  description = "AzureDevOps PAT"
+  type        = string
+}
+variable "ado_org_service_url" {
+  description = "AzureDevOps Org Service URL"
+  type        = string
+}


### PR DESCRIPTION
Manually:
- Ran web-resource-provisioning.yml to create web resources
- Created Variable group for inputs manually #TODO to create this in preprovisioning pipelines. The variable group contains web variables for CI/CD: "appServiceNameApi", "azureContainerRegistry", "azureSubscriptionEndpoint", "resourceGroupName"
- Added to Application Settings configuration the following values: "AzureDevOpsProjectName", "AzureDevOpsPipelineBuildId", "AzureDevOpsUri", and "AzureDevOpsPersonalAccessToken" (See below for example inputs, the pipeline that we are triggering is the network module currently)
- Created CI/CD pipelines from api-webapp-CI and api-webapp-CD
- Triggered CI and then CD pipelines

Application Settings Configuration example values (not shown is PAT) 
![image](https://user-images.githubusercontent.com/8856246/96053594-abe60980-0e34-11eb-9444-d6ce9965430b.png)

Our Api WebApp currently supports the triggering of the network pipeline. We run CI/CD to create a docker image and push to our ACR then grab the image and deploy to the web app.

![image](https://user-images.githubusercontent.com/8856246/96052983-7ab90980-0e33-11eb-94a5-8198d9e8fd9d.png)

Once the WebApp is deployed we go to swagger to kick off the networking pipeline from our WebApp.

![image](https://user-images.githubusercontent.com/8856246/96053930-5f4efe00-0e35-11eb-80c6-4d71c08172e0.png)

![image](https://user-images.githubusercontent.com/8856246/96053954-6ece4700-0e35-11eb-9d3b-b4f0696e7f98.png)

We see that the network pipeline was successfully triggered and that we have the expected resources.

![image](https://user-images.githubusercontent.com/8856246/96054060-accb6b00-0e35-11eb-84bd-cd61c6cb07ba.png)



