### PR TITLE
Bug/preprovisioning/serviceconnection

### DIFF
--- a/azure-devops-pipelines/preprovisioning.yml
+++ b/azure-devops-pipelines/preprovisioning.yml
@@ -15,7 +15,7 @@ parameters:
     default: "westus2"
   - name: ado_project_name
     displayName: ado project name eg.-  MyAzureDevopsProject or Azure-PrivateDevopsAgent-Demos-Ansible-Terraform-Pipelines
-    default: staging-environment-azdo-samples
+    default: Azdo-Modular-Infrastructure-Pipelines
   - name: ado_org_service_url
     displayName: ado org service url eg.-  https://dev.azure.com/csebraveheart
     default: https://dev.azure.com/csebraveheart

--- a/src/terraform/preprovisioning/main.tf
+++ b/src/terraform/preprovisioning/main.tf
@@ -47,7 +47,7 @@ data "azuredevops_projects" "main" {
 
 #Initialize local variables for azuredevops project_id and web resource naming conventions
 locals {
-  project_id = data.azuredevops_projects.main.projects.*.project_id[0]
+  project_id = data.azuredevops_projects.main.id
 
 }
 

--- a/src/terraform/preprovisioning/main.tf
+++ b/src/terraform/preprovisioning/main.tf
@@ -40,14 +40,14 @@ resource "azurerm_resource_group" "main" {
 }
 
 #Import azuredevops project via 
-data "azuredevops_projects" "main" {
+data "azuredevops_project" "main" {
   project_name = var.ado_project_name
   state        = "wellFormed"
 }
 
 #Initialize local variables for azuredevops project_id and web resource naming conventions
 locals {
-  project_id = data.azuredevops_projects.main.id
+  project_id = data.azuredevops_project.main.id
 
 }
 

--- a/src/terraform/preprovisioning/main.tf
+++ b/src/terraform/preprovisioning/main.tf
@@ -42,7 +42,6 @@ resource "azurerm_resource_group" "main" {
 #Import azuredevops project via 
 data "azuredevops_project" "main" {
   project_name = var.ado_project_name
-  state        = "wellFormed"
 }
 
 #Initialize local variables for azuredevops project_id and web resource naming conventions


### PR DESCRIPTION
This PR contains:

Updates to the terrafrom data block. We were previously pulling in Azure DevOps projects and then we just grab the first project in this list to create a service connection. This will only work if we have one Azure DevOps project. Once we have more that one project our code will be an issue since it will only be spinning up service connections in the first project in the list.

This PR updates the data block to use Azure DevOps project instead of Azure DevOps projects so we can support the functionality of spinning up a service connection when we have multiple azure dev ops projects. 

This PR also includes updates to the preprovisioning.yml that updates the default ado_project to Azdo-Modular-Infrastructure-Pipelines which is current ADO public project.